### PR TITLE
List models with correct index number.

### DIFF
--- a/main.c
+++ b/main.c
@@ -53,7 +53,7 @@ static void dump_chips(struct nand_chip (*chips)[], int count, int index)
 
 	for (i=0; i<count; i++) {
 		if (index)
-			fprintf(stderr, "%d:\n", i);
+			fprintf(stderr, "%d:\n", i+1);
 		fprintf(stderr,"  %s\n"
 			"  page_size  : %d\n"
 			"  spare_size : %d\n"


### PR DESCRIPTION
Because the -m option requires model indices starting from 1, it makes sense to consistently list the models on option -l starting with index 1 too. This merge request contains the required change.